### PR TITLE
Do not generate HTTPS certificate in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,4 @@ COPY jupyter-start.sh /usr/local/bin/start.sh
 COPY opt/setup-ispg-things.sh /usr/local/bin/before-notebook.d/59_setup-ispg-things.sh
 RUN chmod a+r /usr/local/bin/before-notebook.d/59_setup-ispg-things.sh
 
-# Automatically generate self-signed SSL certificate
-# and configure notebook for HTTPS connection
-ENV GEN_CERT=yes
-
 WORKDIR "/home/${NB_USER}/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def is_responsive(url):
 def notebook_service(docker_ip, docker_services):
     """Ensure that HTTP service is up and responsive."""
     port = docker_services.port_for("aiidalab", 8888)
-    url = f"https://{docker_ip}:{port}"
+    url = f"http://{docker_ip}:{port}"
     docker_services.wait_until_responsive(
         timeout=60.0, pause=1.0, check=lambda: is_responsive(url)
     )


### PR DESCRIPTION
The HTTPS-by-default broke the tests in `aiidalab-ispg` and also is not very user friendly, since browsers will complain about the certificate not being trusted anyway (and making an exception won't help since the certificates will be different in different containers...).

We need a proper HTTPS support via `aiidalab-launch`. 